### PR TITLE
Fixes #8: allow to set maximumNestingDepth

### DIFF
--- a/src/main/java/com/google/json/EvalMinifier.java
+++ b/src/main/java/com/google/json/EvalMinifier.java
@@ -54,6 +54,19 @@ public final class EvalMinifier {
     return minify(s.toCharSequence()).toString();
   }
 
+  /**
+   * Same as {@link EvalMinifier#minify(String)}, but allows to set custom maximum nesting depth.
+   * @param jsonish a string of JSON-like content as defined by
+   * {@link JsonSanitizer}.
+   * @param maximumNestingDepth the maximum nesting depth for the {@link JsonSanitizer}
+   * @return see {@link EvalMinifier#minify(String)}
+   */
+  public static String minify(String jsonish, int maximumNestingDepth) {
+    JsonSanitizer s = new JsonSanitizer(jsonish, maximumNestingDepth);
+    s.sanitize();
+    return minify(s.toCharSequence()).toString();
+  }
+
   private static CharSequence minify(CharSequence json) {
     Map<Token, Token> pool = new HashMap<Token, Token>();
     int n = json.length();

--- a/src/main/java/com/google/json/JsonSanitizer.java
+++ b/src/main/java/com/google/json/JsonSanitizer.java
@@ -92,13 +92,11 @@ package com.google.json;
  */
 public final class JsonSanitizer {
 
-  /** The default for {@link JsonSanitizer#maximumNestingDepth} */
+  /** The default for {@link JsonSanitizer#maximumNestingDepth}. */
   public static final int DEFAULT_NESTING_DEPTH = 64;
 
-  /**
-   * The maximum nesting depth. According to RFC4627 it is implementation-specific.
-   */
-  private final int maximumNestingDepth;
+  /** The maximum value for {@link JsonSanitizer#maximumNestingDepth}. */
+  public static final int MAXIMUM_NESTING_DEPTH = 4096;
 
   /**
    * Given JSON-like content, produces a string of JSON that is safe to embed,
@@ -156,6 +154,11 @@ public final class JsonSanitizer {
     ;
   }
 
+  /**
+   * The maximum nesting depth. According to RFC4627 it is implementation-specific.
+   */
+  private final int maximumNestingDepth;
+
   private final String jsonish;
 
   /**
@@ -188,11 +191,15 @@ public final class JsonSanitizer {
   }
 
   JsonSanitizer(String jsonish, int maximumNestingDepth) {
-    this.maximumNestingDepth = Math.max(1, maximumNestingDepth);
+    this.maximumNestingDepth = Math.min(Math.max(1, maximumNestingDepth),MAXIMUM_NESTING_DEPTH);
     if (SUPER_VERBOSE_AND_SLOW_LOGGING) {
       System.err.println("\n" + jsonish + "\n========");
     }
     this.jsonish = jsonish != null ? jsonish : "null";
+  }
+
+  int getMaximumNestingDepth() {
+    return this.maximumNestingDepth;
   }
 
   void sanitize() {

--- a/src/main/java/com/google/json/JsonSanitizer.java
+++ b/src/main/java/com/google/json/JsonSanitizer.java
@@ -91,6 +91,15 @@ package com.google.json;
  * code-units.
  */
 public final class JsonSanitizer {
+
+  /** The default for {@link JsonSanitizer#maximumNestingDepth} */
+  public static final int DEFAULT_NESTING_DEPTH = 64;
+
+  /**
+   * The maximum nesting depth. According to RFC4627 it is implementation-specific.
+   */
+  private final int maximumNestingDepth;
+
   /**
    * Given JSON-like content, produces a string of JSON that is safe to embed,
    * safe to pass to JavaScript's {@code eval} operator.
@@ -99,7 +108,17 @@ public final class JsonSanitizer {
    * @return embeddable JSON
    */
   public static String sanitize(String jsonish) {
-    JsonSanitizer s = new JsonSanitizer(jsonish);
+    return sanitize(jsonish, DEFAULT_NESTING_DEPTH);
+  }
+
+  /**
+   * Same as {@link JsonSanitizer#sanitize(String)}, but allows to set a custom maximum nesting depth.
+   *
+   * @param jsonish JSON-like content.
+   * @return embeddable JSON
+   */
+  public static String sanitize(String jsonish, int maximumNestingDepth) {
+    JsonSanitizer s = new JsonSanitizer(jsonish, maximumNestingDepth);
     s.sanitize();
     return s.toString();
   }
@@ -165,6 +184,11 @@ public final class JsonSanitizer {
   private static final boolean SUPER_VERBOSE_AND_SLOW_LOGGING = false;
 
   JsonSanitizer(String jsonish) {
+    this(jsonish, DEFAULT_NESTING_DEPTH);
+  }
+
+  JsonSanitizer(String jsonish, int maximumNestingDepth) {
+    this.maximumNestingDepth = Math.max(1, maximumNestingDepth);
     if (SUPER_VERBOSE_AND_SLOW_LOGGING) {
       System.err.println("\n" + jsonish + "\n========");
     }
@@ -217,7 +241,7 @@ public final class JsonSanitizer {
           case '{': case '[':
             state = requireValueState(i, state, false);
             if (isMap == null) {
-              isMap = new boolean[64];
+              isMap = new boolean[maximumNestingDepth];
             }
             boolean map = ch == '{';
             isMap[bracketDepth] = map;

--- a/src/test/java/com/google/json/JsonSanitizerTest.java
+++ b/src/test/java/com/google/json/JsonSanitizerTest.java
@@ -14,15 +14,22 @@
 
 package com.google.json;
 
-import org.junit.Test;
-
+import static com.google.json.JsonSanitizer.DEFAULT_NESTING_DEPTH;
+import static com.google.json.JsonSanitizer.sanitize;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import junit.framework.TestCase;
+import org.junit.Test;
 
 @SuppressWarnings({ "javadoc", "static-method" })
 public final class JsonSanitizerTest extends TestCase {
 
   private static void assertSanitized(String golden, String input) {
-    String actual = JsonSanitizer.sanitize(input);
+    assertSanitized(golden, input, DEFAULT_NESTING_DEPTH);
+  }
+
+  private static void assertSanitized(String golden, String input, int maximumNestingDepth) {
+    String actual = sanitize(input, maximumNestingDepth);
     assertEquals(input, golden, actual);
     if (actual.equals(input)) {
       assertSame(input, input, actual);
@@ -168,5 +175,21 @@ public final class JsonSanitizerTest extends TestCase {
     assertSanitized("\"devcomment\"", "dev\\comment");
     assertSanitized("\"dev\\ncomment\"", "dev\\ncomment");
     assertSanitized("[\"dev\", \"comment\"]", "[dev\\, comment]");
+  }
+
+  @Test
+  public final void testMaximumNestingLevel() {
+    String nestedMaps = "{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}";
+    String sanitizedNestedMaps = "{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{\"\":{}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}";
+
+    boolean exceptionIfTooMuchNesting = false;
+    try {
+      assertSanitized(sanitizedNestedMaps, nestedMaps, DEFAULT_NESTING_DEPTH);
+    } catch (ArrayIndexOutOfBoundsException e) {
+      Logger.getAnonymousLogger().log(Level.FINEST, "Expected exception in testing maximum nesting level", e);
+      exceptionIfTooMuchNesting = true;
+    }
+    assertTrue("Expecting failure for too nested JSON", exceptionIfTooMuchNesting);
+    assertSanitized(sanitizedNestedMaps, nestedMaps, DEFAULT_NESTING_DEPTH + 1);
   }
 }

--- a/src/test/java/com/google/json/JsonSanitizerTest.java
+++ b/src/test/java/com/google/json/JsonSanitizerTest.java
@@ -192,4 +192,10 @@ public final class JsonSanitizerTest extends TestCase {
     assertTrue("Expecting failure for too nested JSON", exceptionIfTooMuchNesting);
     assertSanitized(sanitizedNestedMaps, nestedMaps, DEFAULT_NESTING_DEPTH + 1);
   }
+
+  @Test
+  public final void testMaximumNestingLevelAssignment() {
+    assertEquals(1, new JsonSanitizer("", Integer.MIN_VALUE).getMaximumNestingDepth());
+    assertEquals(JsonSanitizer.MAXIMUM_NESTING_DEPTH, new JsonSanitizer("", Integer.MAX_VALUE).getMaximumNestingDepth());
+  }
 }


### PR DESCRIPTION
Add two public methods (to `EvalMinifier` and `JsonSanitizer`) that allow setting a custom maximum
nesting depth.

Adds a test method for this behavior (see `JsonSanitizerTest`).