### PR TITLE
Escape <!--, --> and <script

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ The output is well-formed JSON as defined by
 [RFC 4627](http://www.ietf.org/rfc/rfc4627.txt).
 The output satisfies these additional properties:
 
- * The output will not contain the substring (case-insensitively) `"</script"` so can be embedded inside an HTML script element without further encoding.
- * The output will not contain the substring `"]]>"` so can be embedded inside an XML CDATA section without further encoding.
+ * The output will not contain the substrings (case-insensitively) `"<script"`, `"</script"` and `<!--` and can thus be embedded inside an HTML script element without further encoding.
+ * The output will not contain the substring `"]]>"` and can thus be embedded inside an XML CDATA section without further encoding.
  * The output is a valid Javascript expression, so can be parsed by Javascript's `eval` builtin (after being wrapped in parentheses) or by `JSON.parse`.  Specifically, the output will not contain any string literals with embedded JS newlines (U+2028 Paragraph separator or U+2029 Line separator).
  * The output contains only valid Unicode [scalar values](http://www.unicode.org/glossary/#unicode_scalar_value) (no isolated [UTF-16 surrogates](http://www.unicode.org/glossary/#surrogate_pair)) that are [allowed in XML](http://www.w3.org/TR/xml/#charsets) unescaped.
 

--- a/src/test/java/com/google/json/JsonSanitizerTest.java
+++ b/src/test/java/com/google/json/JsonSanitizerTest.java
@@ -56,14 +56,12 @@ public final class JsonSanitizerTest extends TestCase {
     assertSanitized("\"foo\"");
     assertSanitized("\"foo\"", "'foo'");
     assertSanitized(
-        "\"<script>foo()<\\/script>\"", "\"<script>foo()</script>\"");
-    assertSanitized(
-        "\"<script>foo()<\\/script>\"", "\"<script>foo()</script>\"");
-    assertSanitized("\"<\\/SCRIPT\\n>\"", "\"</SCRIPT\n>\"");
-    assertSanitized("\"<\\/ScRIpT\"", "\"</ScRIpT\"");
+        "\"\\u003cscript>foo()\\u003c/script>\"", "\"<script>foo()</script>\"");
+    assertSanitized("\"\\u003c/SCRIPT\\n>\"", "\"</SCRIPT\n>\"");
+    assertSanitized("\"\\u003c/ScRIpT\"", "\"</ScRIpT\"");
     // \u0130 is a Turkish dotted upper-case 'I' so the lower case version of
     // the tag name is "script".
-    assertSanitized("\"<\\/ScR\u0130pT\"", "\"</ScR\u0130pT\"");
+    assertSanitized("\"\\u003c/ScR\u0130pT\"", "\"</ScR\u0130pT\"");
     assertSanitized("\"<b>Hello</b>\"");
     assertSanitized("\"<s>Hello</s>\"");
     assertSanitized("\"<[[\\u005d]>\"", "'<[[]]>'");
@@ -210,5 +208,24 @@ public final class JsonSanitizerTest extends TestCase {
     assertSanitized(
         "[ { \"description\": \"aa##############aa\" }, 1 ]",
         "[ { \"description\": \"aa##############aa\" }, 1 ]");
+  }
+
+  @Test
+  public static final void testHtmlParserStateChanges() {
+    assertSanitized("\"\\u003cscript\"", "\"<script\"");
+    assertSanitized("\"\\u003cScript\"", "\"<Script\"");
+    // \u0130 is a Turkish dotted upper-case 'I' so the lower case version of
+    // the tag name is "script".
+    assertSanitized("\"\\u003cScR\u0130pT\"", "\"<ScR\u0130pT\"");
+    assertSanitized("\"\\u003cSCRIPT\\n>\"", "\"<SCRIPT\n>\"");
+    assertSanitized("\"script\"", "<script");
+
+    assertSanitized("\"\\u003c!--\"", "\"<!--\"");
+    assertSanitized("-0", "<!--");
+
+    assertSanitized("\"--\\u003e\"", "\"-->\"");
+    assertSanitized("-0", "-->");
+
+    assertSanitized("\"\\u003c!--\\u003cscript>\"", "\"<!--<script>\"");
   }
 }


### PR DESCRIPTION
In HTML script elements, `</script` is not the only substring that switches the HTML parser state even when contained in a JS string literal. This commit adds escaping for `<!--`, `-->` and `<script`, which appear to be all substrings that cause state transitions which are not reset by the `"` closing the string literal.

The injection of `<!--`, `-->` and `<script` in script elements is less severe than that of `</script` since they do not directly allow the execution of arbitrary HTML/JS. However, they could potentially be used to selectively disable scripts by causing syntax errors.

The following examples demonstrate the effect of these injections in a JSON context. In all cases, the alert is not executed, but will be executed if the value of the `json` variable is replaced with a harmless literal such as "foobar". The first example is the most relevant one since it does not have any further requirements on the contents of the script. The second and especially the third example are much more theoretical, but still valid HTML/JS.

```html
<script>
    var json = "<!--<script>";
    alert("not executed");
</script>
```

```html
<script>
    var unrelated_variable = "<!--";
    // ...
    var json = "<script>";
    alert("not executed");
</script>
```

```html
<script>
<!--<script>
    var json = "-->"
</script />
alert("not executed");
</script>
```